### PR TITLE
add type parameters to make javac happy

### DIFF
--- a/gremlin-test/src/main/java/com/tinkerpop/gremlin/process/graph/step/map/OrderTest.java
+++ b/gremlin-test/src/main/java/com/tinkerpop/gremlin/process/graph/step/map/OrderTest.java
@@ -82,7 +82,7 @@ public abstract class OrderTest extends AbstractGremlinTest {
         }
 
         public Traversal<Vertex, String> get_g_V_orderXa_nameXb_nameX_name() {
-            return g.V().order((a, b) -> a.get().<String>value("name").compareTo(b.get().value("name"))).value("name");
+            return g.V().order((a, b) -> a.get().<String>value("name").compareTo(b.get().<String>value("name"))).value("name");
         }
     }
 }

--- a/tinkergraph-gremlin/src/main/java/com/tinkerpop/gremlin/tinkergraph/process/graph/step/map/TinkerGraphStep.java
+++ b/tinkergraph-gremlin/src/main/java/com/tinkerpop/gremlin/tinkergraph/process/graph/step/map/TinkerGraphStep.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -51,7 +52,7 @@ public class TinkerGraphStep<E extends Element> extends GraphStep<E> {
                 TinkerHelper.queryEdgeIndex(this.graph, indexedContainer.key, indexedContainer.value).stream();
 
         // the copy to a new List is intentional as remove() operations will cause ConcurrentModificationException otherwise
-        return (Iterator) edgeStream.filter(e -> HasContainer.testAll((Edge) e, this.hasContainers)).collect(java.util.stream.Collectors.toList()).iterator();
+        return edgeStream.filter(e->HasContainer.testAll(e,hasContainers)).collect(Collectors.<Edge>toList()).iterator();
     }
 
     private Iterator<? extends Vertex> vertices() {
@@ -61,7 +62,7 @@ public class TinkerGraphStep<E extends Element> extends GraphStep<E> {
                 TinkerHelper.queryVertexIndex(this.graph, indexedContainer.key, indexedContainer.value).stream();
 
         // the copy to a new List is intentional as remove() operations will cause ConcurrentModificationException otherwise
-        return (Iterator) vertexStream.filter(v -> HasContainer.testAll((Vertex) v, this.hasContainers)).collect(java.util.stream.Collectors.toList()).iterator();
+        return vertexStream.filter(v -> HasContainer.testAll(v, this.hasContainers)).collect(Collectors.<Vertex>toList()).iterator();
     }
 
     private HasContainer getIndexKey(final Class<? extends Element> indexedClass) {


### PR DESCRIPTION
project failed to compile with java 1.8.0_20, emitting the following errors...

Information:Using javac 1.8.0_20-ea to compile java sources

Users/jason/IdeaProjects/tinkerpop3/gremlin-test/src/main/java/com/tinkerpop/gremlin/process/graph/step/map/OrderTest.java
    Error:Error:line (85)java: incompatible types: java.lang.Object cannot be converted to java.lang.String

/Users/jason/IdeaProjects/tinkerpop3/tinkergraph-gremlin/src/main/java/com/tinkerpop/gremlin/tinkergraph/process/graph/step/map/TinkerGraphStep.java
    Error:Error:line (54)java: no suitable method found for collect(java.util.stream.Collector<java.lang.Object,capture#1 of ?,java.util.List<java.lang.Object>>)
    method java.util.stream.Stream.<R>collect(java.util.function.Supplier<R>,java.util.function.BiConsumer<R,? super capture#2 of ? extends com.tinkerpop.gremlin.structure.Edge>,java.util.function.BiConsumer<R,R>) is not applicable
      (cannot infer type-variable(s) R
        (actual and formal argument lists differ in length))
    method java.util.stream.Stream.<R,A>collect(java.util.stream.Collector<? super capture#2 of ? extends com.tinkerpop.gremlin.structure.Edge,A,R>) is not applicable
      (cannot infer type-variable(s) R,A,capture#3 of ?,T
        (argument mismatch; java.util.stream.Collector<capture#2 of ? extends com.tinkerpop.gremlin.structure.Edge,capture#4 of ?,java.util.List<capture#2 of ? extends com.tinkerpop.gremlin.structure.Edge>> cannot be converted to java.util.stream.Collector<? super capture#2 of ? extends com.tinkerpop.gremlin.structure.Edge,capture#4 of ?,java.util.List<capture#2 of ? extends com.tinkerpop.gremlin.structure.Edge>>))
    Error:Error:line (64)java: no suitable method found for collect(java.util.stream.Collector<java.lang.Object,capture#5 of ?,java.util.List<java.lang.Object>>)
    method java.util.stream.Stream.<R>collect(java.util.function.Supplier<R>,java.util.function.BiConsumer<R,? super capture#6 of ? extends com.tinkerpop.gremlin.structure.Vertex>,java.util.function.BiConsumer<R,R>) is not applicable
      (cannot infer type-variable(s) R
        (actual and formal argument lists differ in length))
    method java.util.stream.Stream.<R,A>collect(java.util.stream.Collector<? super capture#6 of ? extends com.tinkerpop.gremlin.structure.Vertex,A,R>) is not applicable
      (cannot infer type-variable(s) R,A,capture#7 of ?,T
        (argument mismatch; java.util.stream.Collector<capture#6 of ? extends com.tinkerpop.gremlin.structure.Vertex,capture#8 of ?,java.util.List<capture#6 of ? extends com.tinkerpop.gremlin.structure.Vertex>> cannot be converted to java.util.stream.Collector<? super capture#6 of ? extends com.tinkerpop.gremlin.structure.Vertex,capture#8 of ?,java.util.List<capture#6 of ? extends com.tinkerpop.gremlin.structure.Vertex>>))
