### PR TITLE
Require FEATURE_SERIALIZABLE_VALUES for SerializeCustomId tests

### DIFF
--- a/gremlin-test/src/main/java/com/tinkerpop/gremlin/structure/IoTest.java
+++ b/gremlin-test/src/main/java/com/tinkerpop/gremlin/structure/IoTest.java
@@ -190,6 +190,7 @@ public class IoTest extends AbstractGremlinTest {
      */
     @Test
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = FEATURE_USER_SUPPLIED_IDS)
+    @FeatureRequirement(featureClass = VertexPropertyFeatures.class, feature = VertexPropertyFeatures.FEATURE_SERIALIZABLE_VALUES)
     public void shouldProperlySerializeDeserializeCustomIdWithGraphSON() throws Exception {
         final UUID id = UUID.fromString("AF4B5965-B176-4552-B3C1-FBBE2F52C305");
         g.addVertex(Element.ID, new CustomId("vertex", id));
@@ -235,6 +236,7 @@ public class IoTest extends AbstractGremlinTest {
 
     @Test
     @FeatureRequirement(featureClass = Graph.Features.VertexFeatures.class, feature = FEATURE_USER_SUPPLIED_IDS)
+    @FeatureRequirement(featureClass = VertexPropertyFeatures.class, feature = VertexPropertyFeatures.FEATURE_SERIALIZABLE_VALUES)
     public void shouldProperlySerializeCustomIdWithKryo() throws Exception {
         g.addVertex(Element.ID, new CustomId("vertex", UUID.fromString("AF4B5965-B176-4552-B3C1-FBBE2F52C305")));
         final GremlinKryo kryo = GremlinKryo.create().addCustom(CustomId.class).build();


### PR DESCRIPTION
I am not 100% certain this is the right fix. But a PR seems like the simplest way to arrange any needed discussion.

The question is, if you `supportsUserSuppliedIds`, what data types are allowed for those ids? I am pretty certain that the intention isn't to require any Java data type. Perhaps the corresponding property features is a logical choice. That's what I've done here. But I could well imagine a database with stricter requirements. For example, a `Double` key is a recipe for trouble; among other things if you make one with `NaN` you may or may not be able to find it again, depending on the details of the implementation. Still, a whole new `DataTypeFeatures` for user-supplied ids feels like overkill.
