### PR TITLE
use assertThat(a, not(b)) which a) works and b) provides better error me...

### DIFF
--- a/gremlin-test/src/main/java/com/tinkerpop/gremlin/process/graph/step/sideEffect/AggregateTest.java
+++ b/gremlin-test/src/main/java/com/tinkerpop/gremlin/process/graph/step/sideEffect/AggregateTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import static com.tinkerpop.gremlin.LoadGraphWith.GraphData.MODERN;
 import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -73,7 +74,7 @@ public abstract class AggregateTest extends AbstractGremlinTest {
             Path path = traversal.next();
             String first = path.get(0).toString();
             String second = path.get(1).toString();
-            assertNotEquals(first, second);
+            assertThat(first, not(second));
             MapHelper.incr(firstStepCounts, first, 1l);
             MapHelper.incr(secondStepCounts, second, 1l);
         }


### PR DESCRIPTION
...ssages

I had some problems extending AggregateTest, and they seemed to be around JUnit's assertNotEquals. I have replaced it with assertThat, which is the better option anyway as it provides context when the test fails:
http://stackoverflow.com/questions/1096650/why-doesnt-junit-provide-assertnotequals-methods
