### PR TITLE
Append plugin dirs to $CLASSPATH alphabetically

### DIFF
--- a/gremlin-console/src/main/bin/gremlin.sh
+++ b/gremlin-console/src/main/bin/gremlin.sh
@@ -20,7 +20,8 @@ while [ -h "$SOURCE" ]; do
   [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-CP=$CP:$(find -L $DIR/../ext/ -name "*.jar" | tr '\n' ':')
+CP=$CP:$( find -L "$DIR"/../ext -mindepth 1 -maxdepth 1 -type d | \
+          sort | sed 's/$/\/*/' | tr '\n' ':' )
 
 export CLASSPATH="${CLASSPATH:-}:$CP"
 


### PR DESCRIPTION
This change makes gremlin.sh append the `ext/<plugin-dir>` elements to the Console's classpath in alphabetical order according to the plugin-dir names.  The previous behavior was dependent on the filesystem's underlying order of directory entries, which was not generally meaningful or obvious.

This commit also changes gremlin.sh to use wildcard classpath elements for plugins, e.g. "ext/hadoop-gremlin/*".  This assumes that `ext/<plugin-dir>/` has no internal subdirectories (that all of the jars
are immediate children of `<plugin-dir>`), and that the runtime JVM is at least version 6.  The latter is definitely true since TP3 requires Java 8, and I think the former is also true given how gremlin-console installs plugins.

The wildcard change is not absolutely necessary.  The console classpath without wildcards was getting large enough to fill an entire screen of text and still require scrolling to see the whole thing.  It's just a debugging quality-of-life change.
