### PR TITLE
simplified ScriptFormat test case

### DIFF
--- a/gremlin-test/src/main/resources/com/tinkerpop/gremlin/structure/io/script/script-input.groovy
+++ b/gremlin-test/src/main/resources/com/tinkerpop/gremlin/structure/io/script/script-input.groovy
@@ -10,8 +10,8 @@ def parse(line, factory) {
     // process out-edges
     if (parts.length >= 2) {
         parts[1].split(/,/).grep { !it.isEmpty() }.each {
-            def (eLabel, vLabel, refId, weight) = it.split(/:/).toList()
-            def v2 = factory.vertex(refId, vLabel)
+            def (eLabel, refId, weight) = it.split(/:/).toList()
+            def v2 = factory.vertex(refId)
             def edge = factory.edge(v1, v2, eLabel)
             edge.property("weight", Double.valueOf(weight))
         }
@@ -19,8 +19,8 @@ def parse(line, factory) {
     // process in-edges
     if (parts.length == 3) {
         parts[2].split(/,/).grep { !it.isEmpty() }.each {
-            def (eLabel, vLabel, refId, weight) = it.split(/:/).toList()
-            def v2 = factory.vertex(refId, vLabel)
+            def (eLabel, refId, weight) = it.split(/:/).toList()
+            def v2 = factory.vertex(refId)
             def edge = factory.edge(v2, v1, eLabel)
             edge.property("weight", Double.valueOf(weight))
         }

--- a/gremlin-test/src/main/resources/com/tinkerpop/gremlin/structure/io/script/script-output.groovy
+++ b/gremlin-test/src/main/resources/com/tinkerpop/gremlin/structure/io/script/script-output.groovy
@@ -2,8 +2,7 @@ def stringify(vertex) {
     def edgeMap = { vdir ->
         return {
             def e = it.get()
-            def v = e."${vdir}V"().next()
-            e.values("weight").inject(e.label(), v.label(), v.id()).join(":")
+            e.values("weight").inject(e.label(), e."${vdir}V"().next().id()).join(":")
         }
     }
     def v = vertex.values("name", "age", "lang").inject(vertex.id(), vertex.label()).join(":")

--- a/gremlin-test/src/main/resources/com/tinkerpop/gremlin/structure/io/script/tinkerpop-classic.txt
+++ b/gremlin-test/src/main/resources/com/tinkerpop/gremlin/structure/io/script/tinkerpop-classic.txt
@@ -1,6 +1,6 @@
-1:person:marko:29	knows:person:2:0.5,knows:person:4:1.0,created:project:3:0.4
+1:person:marko:29	knows:2:0.5,knows:4:1.0,created:3:0.4
 2:person:vadas:27
 3:project:lop:java
-4:person:josh:32	created:project:3:0.4,created:project:5:1.0
+4:person:josh:32	created:3:0.4,created:5:1.0
 5:project:ripple:java
-6:person:peter:35	created:project:3:0.2
+6:person:peter:35	created:3:0.2

--- a/hadoop-gremlin/src/main/java/com/tinkerpop/gremlin/hadoop/structure/io/script/ScriptRecordReader.java
+++ b/hadoop-gremlin/src/main/java/com/tinkerpop/gremlin/hadoop/structure/io/script/ScriptRecordReader.java
@@ -96,9 +96,17 @@ public class ScriptRecordReader extends RecordReader<NullWritable, VertexWritabl
             this.graph = TinkerGraph.open();
         }
 
+        public Vertex vertex(final Object id) {
+            return vertex(id, Vertex.DEFAULT_LABEL);
+        }
+
         public Vertex vertex(final Object id, final String label) {
             final Traversal<Vertex, Vertex> t = graph.V(id);
             return t.hasNext() ? t.next() : graph.addVertex(T.id, id, T.label, label);
+        }
+
+        public Edge edge(final Vertex out, final Vertex in) {
+            return edge(out, in, Edge.DEFAULT_LABEL);
         }
 
         public Edge edge(final Vertex out, final Vertex in, final String label) {

--- a/hadoop-gremlin/src/test/java/com/tinkerpop/gremlin/hadoop/structure/io/script/ScriptRecordReaderWriterTest.java
+++ b/hadoop-gremlin/src/test/java/com/tinkerpop/gremlin/hadoop/structure/io/script/ScriptRecordReaderWriterTest.java
@@ -68,6 +68,7 @@ public class ScriptRecordReaderWriterTest {
 
                 Vertex vertex = v.get();
                 assertEquals(String.class, vertex.id().getClass());
+                assertTrue(vertex.label().equals("person") || vertex.label().equals("project"));
 
                 Property<String> name = vertex.property("name");
                 if (name.isPresent()) names.remove(name.value());
@@ -83,7 +84,7 @@ public class ScriptRecordReaderWriterTest {
         assertEquals(6, lines.length);
         String line4 = lines[3];
         assertTrue(line4.startsWith("4:person:josh:32"));
-        assertTrue(line4.contains("created:project:5:1.0"));
+        assertTrue(line4.contains("created:5:1.0"));
         //assertTrue(line4.contains("knows:person:1:1.0")); // TODO: requires edge-copy
     }
 


### PR DESCRIPTION
Vertex labels are not necessarily needed for adjacent vertices, so I've made them optional.
