### PR TITLE
Ensure TinkerGraphStep and Neo4jGraphStep narrow on the given ids first.

### DIFF
--- a/neo4j-gremlin/src/main/java/com/tinkerpop/gremlin/neo4j/process/graph/step/sideEffect/Neo4jGraphStep.java
+++ b/neo4j-gremlin/src/main/java/com/tinkerpop/gremlin/neo4j/process/graph/step/sideEffect/Neo4jGraphStep.java
@@ -50,14 +50,20 @@ public class Neo4jGraphStep<E extends Element> extends GraphStep<E> {
 
     private Iterator<? extends Edge> edges() {
         this.graph.tx().readWrite();
+        // ids are present, filter on them first
+        if (this.ids != null && this.ids.length > 0)
+            return IteratorUtils.filter(this.graph.iterators().edgeIterator(this.ids), edge -> HasContainer.testAll((Edge) edge, this.hasContainers));
         final HasContainer hasContainer = this.getHasContainerForAutomaticIndex(Edge.class);
         return (null == hasContainer) ?
-                IteratorUtils.filter(this.graph.iterators().edgeIterator(this.ids), edge -> HasContainer.testAll((Edge) edge, this.hasContainers)) :
+                IteratorUtils.filter(this.graph.iterators().edgeIterator(), edge -> HasContainer.testAll((Edge) edge, this.hasContainers)) :
                 getEdgesUsingAutomaticIndex(hasContainer).filter(edge -> HasContainer.testAll((Edge) edge, this.hasContainers)).iterator();
     }
 
     private Iterator<? extends Vertex> vertices() {
         this.graph.tx().readWrite();
+        // ids are present, filter on them first
+        if (this.ids != null && this.ids.length > 0)
+            return IteratorUtils.filter(this.graph.iterators().vertexIterator(this.ids), vertex -> HasContainer.testAll((Vertex) vertex, this.hasContainers));
         // a label and a property
         final Pair<String, HasContainer> labelHasPair = this.getHasContainerForLabelIndex();
         if (null != labelHasPair)
@@ -73,7 +79,7 @@ public class Neo4jGraphStep<E extends Element> extends GraphStep<E> {
         if (null != labels)
             return this.getVerticesUsingOnlyLabels(labels).filter(vertex -> HasContainer.testAll((Vertex) vertex, this.hasContainers)).iterator();
         // linear scan
-        return IteratorUtils.filter(this.graph.iterators().vertexIterator(this.ids), vertex -> HasContainer.testAll((Vertex) vertex, this.hasContainers));
+        return IteratorUtils.filter(this.graph.iterators().vertexIterator(), vertex -> HasContainer.testAll((Vertex) vertex, this.hasContainers));
     }
 
 

--- a/tinkergraph-gremlin/src/main/java/com/tinkerpop/gremlin/tinkergraph/process/graph/step/sideEffect/TinkerGraphStep.java
+++ b/tinkergraph-gremlin/src/main/java/com/tinkerpop/gremlin/tinkergraph/process/graph/step/sideEffect/TinkerGraphStep.java
@@ -34,20 +34,28 @@ public class TinkerGraphStep<E extends Element> extends GraphStep<E> {
 
     private Iterator<? extends Edge> edges() {
         final HasContainer indexedContainer = getIndexKey(Edge.class);
-        return null == indexedContainer ?
-                this.iteratorList(this.getGraph(TinkerGraph.class).iterators().edgeIterator(this.ids)) :
-                TinkerHelper.queryEdgeIndex(this.getGraph(TinkerGraph.class), indexedContainer.key, indexedContainer.value).stream()
-                        .filter(edge -> ElementHelper.idExists(edge.id(), this.ids) && HasContainer.testAll(edge, this.hasContainers))
-                        .collect(Collectors.<Edge>toList()).iterator();
+        // ids are present, filter on them first
+        if (this.ids != null && this.ids.length > 0)
+            return this.iteratorList(this.getGraph(TinkerGraph.class).iterators().edgeIterator(this.ids));
+        else
+            return null == indexedContainer ?
+                    this.iteratorList(this.getGraph(TinkerGraph.class).iterators().edgeIterator()) :
+                    TinkerHelper.queryEdgeIndex(this.getGraph(TinkerGraph.class), indexedContainer.key, indexedContainer.value).stream()
+                            .filter(edge -> HasContainer.testAll(edge, this.hasContainers))
+                            .collect(Collectors.<Edge>toList()).iterator();
     }
 
     private Iterator<? extends Vertex> vertices() {
         final HasContainer indexedContainer = getIndexKey(Vertex.class);
-        return null == indexedContainer ?
-                this.iteratorList(this.getGraph(TinkerGraph.class).iterators().vertexIterator(this.ids)) :
-                TinkerHelper.queryVertexIndex(this.getGraph(TinkerGraph.class), indexedContainer.key, indexedContainer.value).stream()
-                        .filter(vertex -> ElementHelper.idExists(vertex.id(), this.ids) && HasContainer.testAll(vertex, this.hasContainers))
-                        .collect(Collectors.<Vertex>toList()).iterator();
+        // ids are present, filter on them first
+        if (this.ids != null && this.ids.length > 0)
+            return this.iteratorList(this.getGraph(TinkerGraph.class).iterators().vertexIterator(this.ids));
+        else
+            return null == indexedContainer ?
+                    this.iteratorList(this.getGraph(TinkerGraph.class).iterators().vertexIterator()) :
+                    TinkerHelper.queryVertexIndex(this.getGraph(TinkerGraph.class), indexedContainer.key, indexedContainer.value).stream()
+                            .filter(vertex -> HasContainer.testAll(vertex, this.hasContainers))
+                            .collect(Collectors.<Vertex>toList()).iterator();
     }
 
     private HasContainer getIndexKey(final Class<? extends Element> indexedClass) {


### PR DESCRIPTION
#451 discusses the problem.
Unfortunately I don't think there is a way to actually test the ordering that vertices/edges are retrieved.
I manually checked the execution path.