### PR TITLE
Make path to plugins.txt ignore working dir

### DIFF
--- a/gremlin-console/src/main/bin/gremlin.sh
+++ b/gremlin-console/src/main/bin/gremlin.sh
@@ -69,7 +69,7 @@ done
 shift $(( $OPTIND - 1 ))
 
 if [ -z "${JAVA_OPTIONS:-}" ]; then
-    JAVA_OPTIONS="-Dlog4j.configuration=conf/log4j-repl.properties -Dgremlin.log4j.level=$GREMLIN_LOG_LEVEL"
+    JAVA_OPTIONS="-Dtinkerpop.ext=$DIR/../ext -Dlog4j.configuration=conf/log4j-repl.properties -Dgremlin.log4j.level=$GREMLIN_LOG_LEVEL"
 fi
 
 if [ -n "$SCRIPT_DEBUG" ]; then

--- a/gremlin-console/src/main/groovy/com/tinkerpop/gremlin/console/Mediator.groovy
+++ b/gremlin-console/src/main/groovy/com/tinkerpop/gremlin/console/Mediator.groovy
@@ -17,8 +17,9 @@ class Mediator {
 
     private static String FILE_SEP = System.getProperty("file.separator")
     private static String LINE_SEP = System.getProperty("line.separator")
-    private static
-    final String PLUGIN_CONFIG_FILE = System.getProperty("user.dir") + FILE_SEP + "ext" + FILE_SEP + "plugins.txt"
+
+    private static final String PLUGIN_CONFIG_FILE =
+        System.getProperty("tinkerpop.ext", System.getProperty("user.dir", ".") + FILE_SEP + "ext") + FILE_SEP + "plugins.txt"
 
     public Mediator(final Console console) {
         this.console = console


### PR DESCRIPTION
Mediator's path to plugins.txt includes System.getProperty("user.dir"), and it seems to assume that it's always executed out of the parent of the ext directory.  Running the shell anywhere besides that parent results in plugins not getting loaded since the Mediator can't find plugins.txt.

This commit modifies the gremlin.sh to pass the path to the ext directory as a system property ("tinkerpop.ext").  Mediator now prefers tinkerpop.ext when present, but falls back to user.dir when it's not.  I'm not married to this approach.  It just seemed straightforward, and it seems to fix the problem.

I haven't tested this aside from checking that the shell now prints "plugin activated: ..." as expected regardless of my working directory when I invoke `gremlin.sh`.  There might be other plugin-related working-directory-sensitive problems that arise as a consequence of this change.