### PR TITLE
allow for the retrieval of an Optional instance from Property

### DIFF
--- a/gremlin-core/src/main/java/com/tinkerpop/gremlin/structure/Property.java
+++ b/gremlin-core/src/main/java/com/tinkerpop/gremlin/structure/Property.java
@@ -3,6 +3,7 @@ package com.tinkerpop.gremlin.structure;
 import com.tinkerpop.gremlin.structure.util.empty.EmptyProperty;
 
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -85,6 +86,11 @@ public interface Property<V> {
         if (this.isPresent()) return this.value();
         else
             throw exceptionSupplier.get();
+    }
+
+    @Graph.Helper
+    public default Optional<V> optional() {
+        return this.isPresent() ? Optional.of(this.value()) : Optional.empty();
     }
 
     /**

--- a/gremlin-test/src/main/java/com/tinkerpop/gremlin/structure/PropertyTest.java
+++ b/gremlin-test/src/main/java/com/tinkerpop/gremlin/structure/PropertyTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import static com.tinkerpop.gremlin.structure.Graph.Features.PropertyFeatures.FEATURE_PROPERTIES;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeThat;
 
@@ -95,6 +97,16 @@ public class PropertyTest {
             } catch (Exception ex) {
                 fail("Removing an edge property that was already removed should not throw an exception");
             }
+        }
+
+        @Test
+        @FeatureRequirementSet(FeatureRequirementSet.Package.SIMPLE)
+        @FeatureRequirement(featureClass = Graph.Features.PropertyFeatures.class, feature = PropertyFeatures.FEATURE_PROPERTIES)
+        public void shouldAllowForConversionOfPropertyValueToOptional() {
+            final Vertex v = g.addVertex("name", "marko");
+            tryCommit(g);
+            assertTrue(v.property("name").optional().isPresent());
+            assertFalse(v.property("notpresent").optional().isPresent());
         }
     }
 


### PR DESCRIPTION
While Property already has shortcuts to several `Optional`-like methods (ifPresent, orElse, etc.), it is missing some others.  I would like to be able to write code like:

```java
v.<Long>property("date").optional().map(DateTime::new).ifPresent(model::setDate)
``` 
